### PR TITLE
Handle strategies with no parameters

### DIFF
--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -41,6 +41,16 @@ class TestFactory(TestCase):
         assert not result[0](basically_anything_here='foo')
         assert log.warning.called
 
+    def test_no_parameter(self):
+        strategies = {'Foo': mock.Mock(return_value='R')}
+        feature = {'strategies': [
+            {'name': 'Foo'},
+        ]}
+
+        result = features.feature_gates(strategies, feature)
+        assert len(result) == 1
+        assert result == ['R']
+
 
 class TestFeature(TestCase):
     def test_happy_path(self):

--- a/unleash_client/features.py
+++ b/unleash_client/features.py
@@ -6,7 +6,7 @@ log = logging.getLogger(__name__)
 def feature_gates(strategies, feature):
     tests = []
     for args in feature['strategies']:
-        name, parameters = args['name'], args['parameters']
+        name, parameters = args['name'], args.get('parameters', {})
         strategy = strategies.get(name)
         if strategy:
             test = strategy(**parameters)


### PR DESCRIPTION
Querying a simple default feature toggle fails with `KeyError: 'parameters'`. 

This happens because the default activation strategy does not have a parameter attached to it, e.g. the payload from the unleash server looks like this:
```
{'version': 1, 'features': [
    {'name': 'toggle1', 'description': 'initial feature toggle', 'enabled': True,
     'strategies': [{'name': 'default'}], 'createdAt': '2018-09-11T06:34:09.973Z'}]}
```

This fixes the issue.