### PR TITLE
Add support for custom HTTP headers when talking to the unleash server

### DIFF
--- a/unleash_client/__init__.py
+++ b/unleash_client/__init__.py
@@ -8,6 +8,7 @@ log = logging.getLogger(__name__)
 
 def client(
     url='',
+    headers=None,
     refresh_interval=60,
     fetch=None,
     *al,
@@ -22,9 +23,9 @@ def client(
     elif url.startswith('file:///'):
         fetch = FileFetcher(url[8:])
     elif url.startswith('http://') or url.startswith('https://'):
-        fetch = UrlFetcher(url + '/api/features', refresh_interval)
+        fetch = UrlFetcher(url + '/api/features', refresh_interval, headers)
     else:
         log.error("Unexpected unleash client url scheme: %r", url)
         raise ValueError(url)
 
-    return Client('', *al, fetch=fetch, **kw)
+    return Client(url, headers, *al, fetch=fetch, **kw)

--- a/unleash_client/__main__.py
+++ b/unleash_client/__main__.py
@@ -2,6 +2,7 @@ import argparse
 import random
 import logging
 import time
+import json
 
 from unleash_client import client
 
@@ -19,6 +20,13 @@ argparser.add_argument(
     '-u', '--url',
     default='http://localhost:4242',
     help='URL base for the Unleash feature toggle service',
+)
+
+argparser.add_argument(
+    '-H', '--headers',
+    default='{}',
+    type=json.loads,
+    help='HTTP Header json encoded when making requests to the Unleash feature toggle service',
 )
 
 argparser.add_argument(
@@ -70,6 +78,7 @@ def main(args):
 
     un = client(
         url=ns.url,
+        headers=ns.headers,
         refresh_interval=5,
         metrics_interval=2,
     )

--- a/unleash_client/clients.py
+++ b/unleash_client/clients.py
@@ -19,6 +19,7 @@ class Client:
     def __init__(
             self,
             url='http://localhost:4242',
+            headers=None,
             app_name='anon-app',
             instance_id=None,
             refresh_interval=60,
@@ -29,12 +30,13 @@ class Client:
             fetch=None,
     ):
         self.url = url
+        self._headers = headers
         self.app_name = app_name
         self.instance_id = instance_id or name_instance()
 
         self.strategies = strategies
         features_url = url + '/api/features'
-        self.fetch = fetch or UrlFetcher(features_url, refresh_interval)
+        self.fetch = fetch or UrlFetcher(features_url, refresh_interval, self._headers)
         self.defs = {}
         self.features = {}
 
@@ -43,6 +45,7 @@ class Client:
                 self,
                 url + '/api/client/metrics',
                 metrics_interval,
+                self._headers,
                 clock=clock,
             )
         else:


### PR DESCRIPTION
This is essential if you have your unleash server protected by an API key.